### PR TITLE
Add Heartbeat command

### DIFF
--- a/asb.h
+++ b/asb.h
@@ -75,6 +75,17 @@
     #endif
 
     /**
+     * Heartbeat interval in milliseconds
+     * 
+     * ASB_HEARTBEAT sets the interval in ms between two heartbeat messages
+     * sent by the controller in ASB::loop. Default is 60000ms (1 minute).
+     * Set to 0 to disable heartbeat messages and the uptime counter.
+     */
+    #ifndef ASB_HEARTBEAT
+        #define ASB_HEARTBEAT 60000
+    #endif
+
+    /**
      * ASB main controller class
      *
      * This class stores all node parameters, handles packet routing between
@@ -114,6 +125,17 @@
              */
             unsigned int _cfgAddrStop=511;
 
+            /**
+             * Last heartbeat timestamp (milliseconds)
+             */
+            unsigned long _lastHeartbeat=0;
+
+            /**
+             * Arduino's millis() overflow counter. Used to calculate uptime.
+             * Allows for 2^8*50 days of uptime (~35 years)
+             */
+            byte _millisOverflowCounter=0;
+
 
         public:
             /**
@@ -135,6 +157,11 @@
              * @return true if initialized
              */
             bool firstboot(void (*function)());
+
+            /**
+             * Send a heartbeat message
+             */
+            void heartbeat(void);
 
             /**
              * Change Node-ID

--- a/asb_proto.h
+++ b/asb_proto.h
@@ -29,6 +29,7 @@
 
     #define ASB_CMD_LEGACY_8B     0x02
     #define ASB_CMD_BOOT          0x21
+    #define ASB_CMD_HEARTBEAT     0x22
     #define ASB_CMD_REQ           0x40
     #define ASB_CMD_0B            0x50 //0-Bit, generic pulse
     #define ASB_CMD_1B            0x51 //1-Bit, on/off


### PR DESCRIPTION
Adds a new Heartbeat command sent in regular intervals by all controllers.
It contains the uptime of the controller (approx. in days, see below).

**Code Overview (no impl.)**

```c
#define ASB_CMD_HEARTBEAT 0x22

// Heartbeat interval in milliseconds. Set to 0 to disable.
#ifndef ASB_HEARTBEAT
    #define ASB_HEARTBEAT 60000
#endif
```

**Packet Format**

Byte | 0 | 1 | 2 
-------|---|---|---
**Data** | 0x22 | uptime low | uptime high

**Convert Uptime**

```python
# Example: Uptime 51 days
>>> data = [0x22, 6, 1]
>>> round(((data[1]<<24)+(data[2]<<32))/86400000)
51
```