### PR TITLE
Add Modules commands (2)

### DIFF
--- a/docs/msg_types_cmds.md
+++ b/docs/msg_types_cmds.md
@@ -27,7 +27,9 @@ Messages can carry command + max 7 bytes of payload
 | 0x71    | 0              | PONG                                    |
 | 0x80    | 2              | READ_CONFIG                             |
 | 0x81    | 3              | WRITE_CONFIG                            |
-| 0x82    | 2              | COMMIT CONFIG                           |
+| 0x83    | 3              | READ_CONFIG_RESPONSE                    |
+| 0x86    | 0              | Request list of I/O modules             |
+| 0x87    | 4              | Responses to I/O modules request        |
 | 0x85    | 2              | REIDENT                                 |
 | 0xA0    | 2              | Temperature                             |
 | 0xA1    | 2              | Humidity                                |
@@ -49,3 +51,13 @@ Messages can carry command + max 7 bytes of payload
 | 0xD8    | 2              | something per hour |
 | 0xD9    | 2              | something per minute |
 | 0xDA    | 2              | something per second |
+
+
+# ASB I/O Modules
+
+The module types as specified in response to the I/O module request (0x86/0x87).
+
+| Type | Module         |
+|------|----------------|
+| 0x01 | ASB_IO_DIN     |
+| 0x02 | ASB_IO_DOUT    |

--- a/src/asb.cpp
+++ b/src/asb.cpp
@@ -254,7 +254,6 @@
                     data[0] = ASB_CMD_PONG;
                     _busAddr[pkg.meta.busId]->asbSend(ASB_PKGTYPE_UNICAST, pkg.meta.source, _nodeId, pkg.meta.port, 1, data);
                 break;
-                //@todo nodeid
                 case ASB_CMD_CFG_READ:
                     if(pkg.meta.type != ASB_PKGTYPE_UNICAST || pkg.meta.target != _nodeId) break;
                     data[0] = ASB_CMD_CFG_READ_RES;
@@ -264,6 +263,10 @@
                 case ASB_CMD_CFG_WRITE:
                     if(pkg.meta.type != ASB_PKGTYPE_UNICAST || pkg.meta.target != _nodeId) break;
                     EEPROM.write(pkg.data[1] << 8 + pkg.data[2], pkg.data[3]);
+                break;
+                case ASB_CMD_IDENT:
+                    if(pkg.meta.type != ASB_PKGTYPE_UNICAST || pkg.meta.target != _nodeId) break;
+                    setNodeId(pkg.data[1] << 8 + pkg.data[2]);
                 break;
             }
         }

--- a/src/asb.cpp
+++ b/src/asb.cpp
@@ -276,9 +276,10 @@
                             }
                             data[0] = ASB_CMD_RES_MODULES;
                             data[1] = _module[i]->_cfgId;
-                            data[2] = (address >> 8);
-                            data[3] = address;
-                            _busAddr[pkg.meta.busId]->asbSend(ASB_PKGTYPE_UNICAST, pkg.meta.source, _nodeId, pkg.meta.port, 4, data);
+                            data[2] = _module[i]->_mod_type;
+                            data[3] = (address >> 8);
+                            data[4] = address;
+                            _busAddr[pkg.meta.busId]->asbSend(ASB_PKGTYPE_UNICAST, pkg.meta.source, _nodeId, pkg.meta.port, 5, data);
                             delay(4); //Prevent bus congestion
                         }
                     }

--- a/src/asb.cpp
+++ b/src/asb.cpp
@@ -287,8 +287,10 @@
                 case ASB_CMD_CFG_READ:
                     if(pkg.meta.type != ASB_PKGTYPE_UNICAST || pkg.meta.target != _nodeId) break;
                     data[0] = ASB_CMD_CFG_READ_RES;
-                    data[1] = EEPROM.read(pkg.data[1] << 8 + pkg.data[2]);
-                    _busAddr[pkg.meta.busId]->asbSend(ASB_PKGTYPE_UNICAST, pkg.meta.source, _nodeId, pkg.meta.port, 2, data);
+                    data[1] = pkg.data[1];
+                    data[2] = pkg.data[2];
+                    data[3] = EEPROM.read((pkg.data[1] << 8) + pkg.data[2]);
+                    _busAddr[pkg.meta.busId]->asbSend(ASB_PKGTYPE_UNICAST, pkg.meta.source, _nodeId, pkg.meta.port, 4, data);
                 break;
                 case ASB_CMD_CFG_WRITE:
                     if(pkg.meta.type != ASB_PKGTYPE_UNICAST || pkg.meta.target != _nodeId) break;

--- a/src/asb.cpp
+++ b/src/asb.cpp
@@ -254,8 +254,17 @@
                     data[0] = ASB_CMD_PONG;
                     _busAddr[pkg.meta.busId]->asbSend(ASB_PKGTYPE_UNICAST, pkg.meta.source, _nodeId, pkg.meta.port, 1, data);
                 break;
-                //@todo config
                 //@todo nodeid
+                case ASB_CMD_CFG_READ:
+                    if(pkg.meta.type != ASB_PKGTYPE_UNICAST || pkg.meta.target != _nodeId) break;
+                    data[0] = ASB_CMD_CFG_READ_RES;
+                    data[1] = EEPROM.read(pkg.data[1] << 8 + pkg.data[2]);
+                    _busAddr[pkg.meta.busId]->asbSend(ASB_PKGTYPE_UNICAST, pkg.meta.source, _nodeId, pkg.meta.port, 2, data);
+                break;
+                case ASB_CMD_CFG_WRITE:
+                    if(pkg.meta.type != ASB_PKGTYPE_UNICAST || pkg.meta.target != _nodeId) break;
+                    EEPROM.write(pkg.data[1] << 8 + pkg.data[2], pkg.data[3]);
+                break;
             }
         }
 

--- a/src/asb.cpp
+++ b/src/asb.cpp
@@ -58,7 +58,7 @@
 
     void ASB::heartbeat() {
         byte data[3];
-        unsigned long long uptime = (_millisOverflowCounter << 32) + millis();
+        unsigned long long uptime = ((unsigned long long)_millisOverflowCounter << 32) + millis();
         data[0] = ASB_CMD_HEARTBEAT;
         data[1] = (uptime >> 24) & 0xFF;
         data[2] = (uptime >> 32) & 0xFF;
@@ -294,11 +294,11 @@
                 break;
                 case ASB_CMD_CFG_WRITE:
                     if(pkg.meta.type != ASB_PKGTYPE_UNICAST || pkg.meta.target != _nodeId) break;
-                    EEPROM.write(pkg.data[1] << 8 + pkg.data[2], pkg.data[3]);
+                    EEPROM.write((pkg.data[1] << 8) + pkg.data[2], pkg.data[3]);
                 break;
                 case ASB_CMD_IDENT:
                     if(pkg.meta.type != ASB_PKGTYPE_UNICAST || pkg.meta.target != _nodeId) break;
-                    setNodeId(pkg.data[1] << 8 + pkg.data[2]);
+                    setNodeId((pkg.data[1] << 8) + pkg.data[2]);
                 break;
             }
         }

--- a/src/asb_io.h
+++ b/src/asb_io.h
@@ -35,6 +35,11 @@
     class ASB_IO {
         public:
             /**
+             * Type used for identifying the module type
+             */
+            byte _mod_type=0;
+
+            /**
              * Read configuration block starting at provided address
              */
             byte _cfgId=255;

--- a/src/asb_io_din.cpp
+++ b/src/asb_io_din.cpp
@@ -27,6 +27,7 @@
     #include <asb.h>
 
     ASB_IO_DIN::ASB_IO_DIN(byte cfgId) {
+        _mod_type=ASB_IO_TYPE_DIN;
         _cfgId=cfgId;
     }
 

--- a/src/asb_io_dout.cpp
+++ b/src/asb_io_dout.cpp
@@ -27,6 +27,7 @@
     #include <asb.h>
 
     ASB_IO_DOUT::ASB_IO_DOUT(byte cfgId) {
+        _mod_type=ASB_IO_TYPE_DOUT;
         _cfgId=cfgId;
     }
 

--- a/src/asb_proto.h
+++ b/src/asb_proto.h
@@ -63,6 +63,10 @@
     #define ASB_CMD_S_PM          0xD9 //smth per Minute, unsinged int (RPM, Pulse PM, etc)
     #define ASB_CMD_S_PS          0xDA //smth per Second, unsinged int
 
+    /* pre-defined I/O module types */
+    #define ASB_IO_TYPE_DIN       0x01
+    #define ASB_IO_TYPE_DOUT      0x02
+
     /**
      * Packet metadata
      * Contains all data except things related to the actual payload

--- a/src/asb_proto.h
+++ b/src/asb_proto.h
@@ -39,6 +39,8 @@
     #define ASB_CMD_CFG_READ      0x80 //2-byte address, little endian
     #define ASB_CMD_CFG_WRITE     0x81 //2-byte-address + data
     #define ASB_CMD_CFG_READ_RES  0x83 //2-byte-address + data
+    #define ASB_CMD_REQ_MODULES   0x86
+    #define ASB_CMD_RES_MODULES   0x87 //Module_cfgId byte, 2-byte-address
     #define ASB_CMD_IDENT         0x85 //Change local address, 2-byte-address
     #define ASB_CMD_S_TEMP        0xA0 //x*0.1°C, int
     #define ASB_CMD_S_HUM         0xA1 //x*0.1%RH, unsigned int

--- a/src/asb_proto.h
+++ b/src/asb_proto.h
@@ -36,9 +36,9 @@
     #define ASB_CMD_PER           0x52 //%
     #define ASB_CMD_PING          0x70
     #define ASB_CMD_PONG          0x71
-    #define ASB_CMD_CFG_READ      0x80 //2-byte address
+    #define ASB_CMD_CFG_READ      0x80 //2-byte address, little endian
     #define ASB_CMD_CFG_WRITE     0x81 //2-byte-address + data
-    #define ASB_CMD_CFG_COMMIT    0x82 //2-byte-address
+    #define ASB_CMD_CFG_READ_RES  0x83 //2-byte-address + data
     #define ASB_CMD_IDENT         0x85 //Change local address, 2-byte-address
     #define ASB_CMD_S_TEMP        0xA0 //x*0.1°C, int
     #define ASB_CMD_S_HUM         0xA1 //x*0.1%RH, unsigned int


### PR DESCRIPTION
- Implements the **Config** commands (and changes their usage a bit)
  - 16 bit address.
  - `ASB_CMD_CFG_READ` -> `[0x80, addr>>8, addr%255]`
  - `ASB_CMD_CFG_READ_RES` -> `[0x83, addr>>8, addr%255, data]` (response to `ASB_CMD_CFG_READ`)
  - `ASB_CMD_CFG_WRITE` -> `[0x81, addr>>8, addr%255, data]`
- Implements the **Ident** command (0x85)
  - `ASB_CMD_IDENT` -> `[0x85, id>>8, id%255]`
- Implements **Module** commands for fetching information about installed modules
  - `ASB_CMD_REQ_MODULES` -> `[0x86]`
  - `ASB_CMD_RES_MODULES` -> `[0x87, cfg_id, mod_type, addr>>8, addr%255]` (node sends a response per module)
     - `cfg_id`: config id of the `ASB_IO` module (`ASB_IO::_cfg_id`)
     - `mod_type` (`ASB_IO::_mod_type`). Can be one of the following:
        - `ASB_IO_TYPE_DIN = 0x01`
        - `ASB_IO_TYPE_DOUT = 0x02`
        - `0x00` (unknown/not specified)
     - `addr`: Start of the config in the EEPROM (the same address as specified for `ASB_IO::cfgRead`)
- [x] Updates the Docs